### PR TITLE
Add missing NuGet package source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,4 +4,7 @@
         <add key="enabled" value="True" />
         <add key="automatic" value="True" />
     </packageRestore>
+    <packageSources>
+        <add key="BepInEx" value="https://pkgs.dev.azure.com/bepinex/BepInEx/_packaging/BepInExLibs/nuget/v3/index.json" />
+    </packageSources>
 </configuration>


### PR DESCRIPTION
VS cannot find these packages for me, so I replaced them with ones that it can.
Had to downgrade Unity to 5.5, but that shouldn't be a problem as [5.6 didn't introduce any API changes to Input](https://unity3d.com/unity/whats-new/unity-5.6.0)