### PR TITLE
Ignore case in parsing key code string

### DIFF
--- a/UnityInput/UnityInput.cs
+++ b/UnityInput/UnityInput.cs
@@ -35,7 +35,7 @@ namespace BepInEx.Unity
 
         public static KeyCode StrToKeyCode(string name)
         {
-            return (KeyCode)System.Enum.Parse(typeof(KeyCode), name);
+            return (KeyCode)System.Enum.Parse(typeof(KeyCode), name, ignoreCase: true);
         }
 
         private static class Triggers


### PR DESCRIPTION
The input for GetKeyUp will not always be in the same case as the enum value. Luckily there's already an overload for Enum.Parse to solve this.